### PR TITLE
Relax gem version dependency on activerecord

### DIFF
--- a/webdack-uuid_migration.gemspec
+++ b/webdack-uuid_migration.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pg"
 
-  spec.add_dependency 'activerecord', '~> 4.0.0'
+  spec.add_dependency 'activerecord', '~> 4.0'
 
   spec.has_rdoc= 'yard'
 end


### PR DESCRIPTION
This allows to use the gem with Rails 4.1.

I've used it successfully to convert a Rails 4.1.0 app to use UUIDs for all primary and foreign keys.
