### PR TITLE
Working for Rails 5.2.0.alpha

### DIFF
--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -102,14 +102,6 @@ module Webdack
 
         create_foreign_keys(fk_specs.deep_dup)
       end
-      
-      def extract_foreign_key_action(specifier)
-        case specifier
-        when "c"; :cascade
-        when "n"; :nullify
-        when "r"; :restrict
-        end
-      end
 
       private
       # Prepare a fragment that can be used in SQL statements that converts teh data value

--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -90,7 +90,7 @@ module Webdack
       # @param table[Symbol]
       # @note Works only with Rails 4.2 or newer
       def primary_key_and_all_references_to_uuid(table)
-        fk_specs = foreign_keys_into(:cities)
+        fk_specs = foreign_keys_into(table)
 
         drop_foreign_keys(fk_specs)
 

--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -102,6 +102,14 @@ module Webdack
 
         create_foreign_keys(fk_specs.deep_dup)
       end
+      
+      def extract_foreign_key_action(specifier)
+        case specifier
+        when "c"; :cascade
+        when "n"; :nullify
+        when "r"; :restrict
+        end
+      end
 
       private
       # Prepare a fragment that can be used in SQL statements that converts teh data value

--- a/lib/webdack/uuid_migration/schema_helpers.rb
+++ b/lib/webdack/uuid_migration/schema_helpers.rb
@@ -33,6 +33,14 @@ module Webdack
           options
         end
       end
+      
+      def extract_foreign_key_action(specifier)
+        case specifier
+        when "c"; :cascade
+        when "n"; :nullify
+        when "r"; :restrict
+        end
+      end
 
       def drop_foreign_keys(foreign_keys)
         foreign_keys.each do |fk_key_spec|


### PR DESCRIPTION
I'm working on the Rails 5.2.0.alpha release on an application and tried to use this gem. I was using the foreign keys component. 

It first broke on the (typo?) `:cities` reference so I changed that back to `table`. Then it also could not find `extract_foreign_key_action`, with a stack of:

```
-- extract_foreign_key_action("a")
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

undefined method 'extract_foreign_key_action' for #<MyMigrationToUuid:0x00007fa31498f828>
```

In Rails core that is a private method, so I explicitly listed it in `schema_helpers`. Then to be safe I also added `require 'webdack/uuid_migration/schema_helpers'` to my migration.

With those changes it worked exactly as described. Figured I might as well supply you with the PR that worked for me as a thank you for all your hard work! :) 