### PR TITLE
use pgcrypto extension as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ this gem can safely be removed from your applications Gemfile.
 ## Usage
 
 - Put `require 'webdack/uuid_migration/helpers'` in your migration file.
-- Enable `'uuid-ossp'` directly in Postgres database or by adding `enable_extension 'uuid-ossp'` to your migration.
+- Enable `'pgcrypto'` directly in Postgres database or by adding `enable_extension 'pgcrypto'` to your migration.
 - Use methods from {Webdack::UUIDMigration::Helpers} as appropriate.
 
 Example:
@@ -47,7 +47,7 @@ Example:
           dir.up do
             # Good idea to do the following, needs superuser rights in the database
             # Alternatively the extension needs to be manually enabled in the RDBMS
-            enable_extension 'uuid-ossp'
+            enable_extension 'pgcrypto'
 
             primary_key_to_uuid :students
 
@@ -83,7 +83,7 @@ class MigrateWithFk < ActiveRecord::Migration
   def change
     reversible do |dir|
       dir.up do
-        enable_extension 'uuid-ossp'
+        enable_extension 'pgcrypto'
 
         primary_key_and_all_references_to_uuid :cities
       end

--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -7,16 +7,16 @@ module Webdack
 
 
       # Converts primary key from Serial Integer to UUID, migrates all data by left padding with 0's
-      #   sets uuid_generate_v4() as default for the column
+      #   sets gen_random_uuid() as default for the column
       #
       # @param table [Symbol]
       # @param options [hash]
       # @option options [Symbol] :primary_key if not supplied queries the schema (should work most of the times)
-      # @option options [String] :default mechanism to generate UUID for new records, default uuid_generate_v4(),
+      # @option options [String] :default mechanism to generate UUID for new records, default gen_random_uuid(),
       #           which is Rails 4.0.0 default as well
       # @return [none]
       def primary_key_to_uuid(table, options={})
-        default= options[:default] || 'uuid_generate_v4()'
+        default= options[:default] || 'gen_random_uuid()'
 
         column= connection.primary_key(table)
 

--- a/spec/uuid_custom_pk_spec.rb
+++ b/spec/uuid_custom_pk_spec.rb
@@ -6,7 +6,7 @@ class MigrationBase < ActiveRecordMigration
       t.string :name
     end
 
-    enable_extension 'uuid-ossp'
+    enable_extension 'pgcrypto'
   end
 end
 
@@ -42,7 +42,7 @@ class Migration03 < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
-        primary_key_to_uuid :states, default: 'uuid_generate_v1()'
+        primary_key_to_uuid :states, default: 'gen_random_uuid()'
       end
 
       dir.down do
@@ -111,7 +111,7 @@ describe Webdack::UUIDMigration::Helpers do
     }
 
     default_function = State.connection.columns(:states).find { |c| c.name == 'stateid' }.default_function
-    expect(default_function).to eq 'uuid_generate_v1()'
+    expect(default_function).to eq 'gen_random_uuid()'
   end
 
 end

--- a/spec/uuid_migrate_helper_spec.rb
+++ b/spec/uuid_migrate_helper_spec.rb
@@ -4,7 +4,7 @@ class BasicMigration < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
-        enable_extension 'uuid-ossp'
+        enable_extension 'pgcrypto'
 
         primary_key_to_uuid :students
         columns_to_uuid :students, :city_id, :institution_id
@@ -21,7 +21,7 @@ class MigrateAllOneGo < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
-        enable_extension 'uuid-ossp'
+        enable_extension 'pgcrypto'
 
         primary_key_to_uuid :cities
         primary_key_to_uuid :colleges
@@ -42,7 +42,7 @@ class MigrateWithFk < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
-        enable_extension 'uuid-ossp'
+        enable_extension 'pgcrypto'
 
         primary_key_and_all_references_to_uuid :cities
       end
@@ -58,7 +58,7 @@ class MigrateStep01 < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
-        enable_extension 'uuid-ossp'
+        enable_extension 'pgcrypto'
 
         primary_key_to_uuid :cities
         primary_key_to_uuid :colleges
@@ -157,7 +157,7 @@ describe Webdack::UUIDMigration::Helpers do
       end
 
       # Verify that primary key has correct default
-      expect(columns.find{|c| c.name == 'id'}.default_function).to eq 'uuid_generate_v4()'
+      expect(columns.find{|c| c.name == 'id'}.default_function).to eq 'gen_random_uuid()'
     end
   end
 

--- a/webdack-uuid_migration.gemspec
+++ b/webdack-uuid_migration.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pg"
+  spec.add_development_dependency "pg", '<= 1.0'
   spec.add_development_dependency 'gem-release'
 
   spec.add_dependency 'activerecord', '>= 4.0'


### PR DESCRIPTION
Fix for #7 
- Uses the newer crypto library now favoured for postgres uuid generation.
- Requires all references to enable_extension 'uuid-ossp' switched over to 'pgcrypto'
- Changes default uuid generation from uuid-ossp's 'uuid_generate_v4()' over to pgcrypto's 'gen_random_uuid()'

*Note:* I was not able to run tests for this locally, so please have a look yourself.  This is the optimistic "happy path" switch that assumes that these two libraries can be switched out in place from one another here for people freshly installing uuid support into their Rails apps.