### PR TITLE
Improve to_uuid_pg

### DIFF
--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -110,7 +110,7 @@ module Webdack
       # @param column [Symbol]
       # @return [String]
       def to_uuid_pg(column)
-        "uuid_in(md5(column)::cstring)"
+        "uuid_in(md5(column::text)::cstring)"
       end
     end
   end

--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -110,7 +110,7 @@ module Webdack
       # @param column [Symbol]
       # @return [String]
       def to_uuid_pg(column)
-        "uuid_in(md5(column::text)::cstring)"
+        "uuid_in(md5(#{column}::text)::cstring)"
       end
     end
   end

--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -110,7 +110,7 @@ module Webdack
       # @param column [Symbol]
       # @return [String]
       def to_uuid_pg(column)
-        "uuid(lpad(replace(text(#{column}),'-',''), 32, '0'))"
+        "gen_random_uuid"
       end
     end
   end

--- a/lib/webdack/uuid_migration/helpers.rb
+++ b/lib/webdack/uuid_migration/helpers.rb
@@ -110,7 +110,7 @@ module Webdack
       # @param column [Symbol]
       # @return [String]
       def to_uuid_pg(column)
-        "gen_random_uuid"
+        "uuid_in(md5(column)::cstring)"
       end
     end
   end

--- a/spec/uuid_migrate_helper_spec.rb
+++ b/spec/uuid_migrate_helper_spec.rb
@@ -143,7 +143,7 @@ describe Webdack::UUIDMigration::Helpers do
 
       # Verify that data in id columns have been migrated to UUID by verifying the format
       [student.id, student.city_id, student.institution_id].each do |id|
-        expect(id).to match(/^0{8}-0{4}-0{4}-0{4}-\d{12}$/)
+        expect(id).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
       end
 
       # Verify that it is possible to retirve original id values


### PR DESCRIPTION
Generate more "random" way while keeping correct foreign key reference across tables.

```sql
SELECT uuid_in(md5('1'::text)::cstring) => c4ca4238-a0b9-2382-0dcc-509a6f75849b
SELECT uuid_in(md5('1'::text)::cstring) => c4ca4238-a0b9-2382-0dcc-509a6f75849b # same as above yay!
SELECT uuid_in(md5('2'::text)::cstring) => c81e728d-9d4c-2f63-6f06-7f89cc14862c
SELECT uuid_in(md5('3'::text)::cstring) => eccbc87e-4b5c-e2fe-2830-8fd9f2a7baf3
```