### PR TITLE
Enable the generation of random UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ this gem can safely be removed from your applications Gemfile.
 
 - Put `require 'webdack/uuid_migration/helpers'` in your migration file.
 - Enable `'pgcrypto'` directly in Postgres database or by adding `enable_extension 'pgcrypto'` to your migration.
-  If you want to generate random UUIDs, enable `uuid-ossp` instead.
+  If you want to generate random UUIDs, enable `uuid-ossp` as well.
 - Use methods from {Webdack::UUIDMigration::Helpers} as appropriate.
 
 Example:

--- a/spec/uuid_migrate_helper_spec.rb
+++ b/spec/uuid_migrate_helper_spec.rb
@@ -167,7 +167,7 @@ describe Webdack::UUIDMigration::Helpers do
           end
     
           unless seed_value
-          # Verify that it is possible to retirve original id values
+            # Verify that it is possible to retirve original id values (only without seed!)
             ids= [student.id, student.city_id, student.institution_id].map{|i| i.gsub('-','').to_i}
             expect(ids).to eq(original_ids)
           end

--- a/spec/uuid_migrate_helper_spec.rb
+++ b/spec/uuid_migrate_helper_spec.rb
@@ -1,13 +1,26 @@
 require_relative 'spec_helper'
+require 'pry'
+
+class ActiveRecordMigration
+  def self.seed_with(seed)
+    @@seed = seed
+    self
+  end
+
+  def seed
+    @@seed
+  end
+end
 
 class BasicMigration < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
         enable_extension 'pgcrypto'
+        enable_extension 'uuid-ossp'
 
-        primary_key_to_uuid :students
-        columns_to_uuid :students, :city_id, :institution_id
+        primary_key_to_uuid :students, seed: seed
+        columns_to_uuid :students, :city_id, :institution_id, seed: seed
       end
 
       dir.down do
@@ -22,13 +35,14 @@ class MigrateAllOneGo < ActiveRecordMigration
     reversible do |dir|
       dir.up do
         enable_extension 'pgcrypto'
+        enable_extension 'uuid-ossp'
 
-        primary_key_to_uuid :cities
-        primary_key_to_uuid :colleges
-        primary_key_to_uuid :schools
+        primary_key_to_uuid :cities, seed: seed
+        primary_key_to_uuid :colleges, seed: seed
+        primary_key_to_uuid :schools, seed: seed
 
-        primary_key_to_uuid :students
-        columns_to_uuid :students, :city_id, :institution_id
+        primary_key_to_uuid :students, seed: seed
+        columns_to_uuid :students, :city_id, :institution_id, seed: seed
       end
 
       dir.down do
@@ -43,8 +57,9 @@ class MigrateWithFk < ActiveRecordMigration
     reversible do |dir|
       dir.up do
         enable_extension 'pgcrypto'
+        enable_extension 'uuid-ossp'
 
-        primary_key_and_all_references_to_uuid :cities
+        primary_key_and_all_references_to_uuid :cities, seed: seed
       end
 
       dir.down do
@@ -59,15 +74,16 @@ class MigrateStep01 < ActiveRecordMigration
     reversible do |dir|
       dir.up do
         enable_extension 'pgcrypto'
+        enable_extension 'uuid-ossp'
 
-        primary_key_to_uuid :cities
-        primary_key_to_uuid :colleges
+        primary_key_to_uuid :cities, seed: seed
+        primary_key_to_uuid :colleges, seed: seed
 
-        primary_key_to_uuid :students
-        columns_to_uuid :students, :city_id
+        primary_key_to_uuid :students, seed: seed
+        columns_to_uuid :students, :city_id, seed: seed
 
         change_column :students, :institution_id, :string
-        polymorphic_column_data_for_uuid :students, :institution, 'College'
+        polymorphic_column_data_for_uuid :students, :institution, 'College', seed: seed
       end
 
       dir.down do
@@ -81,8 +97,8 @@ class MigrateStep02 < ActiveRecordMigration
   def change
     reversible do |dir|
       dir.up do
-        primary_key_to_uuid :schools
-        columns_to_uuid :students, :institution_id
+        primary_key_to_uuid :schools, seed: seed
+        polymorphic_column_data_for_uuid :students, :institution, 'School', seed: seed
       end
 
       dir.down do
@@ -117,152 +133,161 @@ describe Webdack::UUIDMigration::Helpers do
     initial_setup
   end
 
-  describe 'Basic Test' do
-    it 'should migrate keys correctly' do
-      # Select a random student
-      student = Student.all.to_a.sample
+  [nil, SecureRandom.uuid].each do |seed|
+    context "when the seed is #{seed}" do
+      let(:seed_value) { seed }
 
-      # Store these values to check against later
-      original_name= student.name
-      original_ids= [student.id, student.city_id, student.institution_id].map{|i| i.to_i}
+      describe 'Basic Test' do
+        it 'should migrate keys correctly' do
+          # Select a random student
+          student = Student.all.to_a.sample
 
-      # Migrate and verify that all indexes and primary keys are intact
-      expect {
-        BasicMigration.migrate(:up)
-        reset_columns_data
-      }.to_not change {
-        indexes= Student.connection.indexes(:students).sort_by { |i| i.name }.map do |i|
-          [i.table, i.name, i.unique, i.columns, i.lengths, i.orders, i.where]
+          # Store these values to check against later
+          original_name= student.name
+          original_ids= [student.id, student.city_id, student.institution_id].map{|i| i.to_i}
+
+          # Migrate and verify that all indexes and primary keys are intact
+          expect {
+            BasicMigration.seed_with(seed_value).migrate(:up)
+            reset_columns_data
+          }.to_not change {
+            indexes= Student.connection.indexes(:students).sort_by { |i| i.name }.map do |i|
+              [i.table, i.name, i.unique, i.columns, i.lengths, i.orders, i.where]
+            end
+
+            [indexes, Student.connection.primary_key(:students)]
+          }
+
+          # Verify that our data is still there
+          student= Student.where(name: original_name).first
+
+          # Verify that data in id columns have been migrated to UUID by verifying the format
+          [student.id, student.city_id, student.institution_id].each do |id|
+            expect(id).to match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/)
+          end
+    
+          unless seed_value
+          # Verify that it is possible to retirve original id values
+            ids= [student.id, student.city_id, student.institution_id].map{|i| i.gsub('-','').to_i}
+            expect(ids).to eq(original_ids)
+          end
+
+          # Verify that schema reprts the migrated columns to be uuid type
+          columns= Student.connection.columns(:students)
+          [:id, :city_id, :institution_id].each do |column|
+            expect(columns.find{|c| c.name == column.to_s}.type).to eq :uuid
+          end
+
+          # Verify that primary key has correct default
+          expect(columns.find{|c| c.name == 'id'}.default_function).to eq 'gen_random_uuid()'
         end
-
-        [indexes, Student.connection.primary_key(:students)]
-      }
-
-      # Verify that our data is still there
-      student= Student.where(name: original_name).first
-
-      # Verify that data in id columns have been migrated to UUID by verifying the format
-      [student.id, student.city_id, student.institution_id].each do |id|
-        expect(id).to match(/^0{8}-0{4}-0{4}-0{4}-\d{12}$/)
       end
 
-      # Verify that it is possible to retirve original id values
-      ids= [student.id, student.city_id, student.institution_id].map{|i| i.gsub('-','').to_i}
-      expect(ids).to eq(original_ids)
-
-      # Verify that schema reprts the migrated columns to be uuid type
-      columns= Student.connection.columns(:students)
-      [:id, :city_id, :institution_id].each do |column|
-        expect(columns.find{|c| c.name == column.to_s}.type).to eq :uuid
+      it 'should migrate entire database in one go' do
+        expect {
+          MigrateAllOneGo.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+        }.to_not change {
+          key_relationships
+        }
       end
 
-      # Verify that primary key has correct default
-      expect(columns.find{|c| c.name == 'id'}.default_function).to eq 'gen_random_uuid()'
+      it 'should migrate a primary key and all columns referencing it using foreign keys', rails_4_2_or_newer: true do
+        # Create 2 more tables similar to the way new version of Rails will do
+        create_tables_with_fk
+
+        # Add Foreign key for this reference as well
+        ActiveRecord::Base.connection.add_foreign_key :students, :cities
+
+        expect {
+          MigrateWithFk.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+        }.to_not change {
+          key_relationships
+        }
+      end
+
+      it 'should handle nulls' do
+        Student.create(name: 'Student without city or institution')
+
+        expect {
+          MigrateAllOneGo.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+        }.to_not change {
+          key_relationships
+        }
+      end
+
+      it 'should migrate in steps for polymorphic association' do
+        expect {
+          MigrateStep01.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+        }.to_not change {
+          key_relationships
+        }
+
+        expect {
+          MigrateStep02.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+          
+        }.to_not change {
+          key_relationships
+        }
+      end
+
+      it 'should allow running same migration data even if it was already migrated' do
+        expect {
+          MigrateStep01.seed_with(seed_value).migrate(:up)
+          # Run again
+          MigrateStep01.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+        }.to_not change {
+          key_relationships
+        }
+
+        expect {
+          MigrateStep02.seed_with(seed_value).migrate(:up)
+          # Run again
+          MigrateStep02.seed_with(seed_value).migrate(:up)
+          reset_columns_data
+        }.to_not change {
+          key_relationships
+        }
+      end
+
+      it 'should allow updation, deletion, and new entity creation' do
+        MigrateAllOneGo.seed_with(seed_value).migrate(:up)
+        reset_columns_data
+
+        # Select a random student
+        student = Student.all.to_a.sample
+
+        id= student.id
+        student.name= 'New student 01'
+        student.save
+        student = Student.find(id)
+
+        expect(student.name).to eq 'New student 01'
+
+        expect { student.destroy }.to change { Student.count }.by(-1)
+
+        expect {Student.find(id)}.to raise_exception(ActiveRecord::RecordNotFound)
+
+        student= Student.create(
+            name: 'New student 02',
+            city: City.where(name: 'City 2').first,
+            institution: School.where(name: 'School 1').first
+        )
+
+        expect(City.where(name: 'City 2').first.students.where(name: 'New student 02').first.name).to eq 'New student 02'
+        expect(School.where(name: 'School 1').first.students.where(name: 'New student 02').first.name).to eq 'New student 02'
+
+        College.where(name: 'College 3').first.students << student
+
+        student.reload
+
+        expect(student.institution.name).to eq 'College 3'
+      end
     end
-  end
-
-  it 'should migrate entire database in one go' do
-    expect {
-      MigrateAllOneGo.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-  end
-
-  it 'should migrate a primary key and all columns referencing it using foreign keys', rails_4_2_or_newer: true do
-    # Create 2 more tables similar to the way new version of Rails will do
-    create_tables_with_fk
-
-    # Add Foreign key for this reference as well
-    ActiveRecord::Base.connection.add_foreign_key :students, :cities
-
-    expect {
-      MigrateWithFk.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-  end
-
-  it 'should handle nulls' do
-    Student.create(name: 'Student without city or institution')
-
-    expect {
-      MigrateAllOneGo.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-  end
-
-  it 'should migrate in steps for polymorphic association' do
-    expect {
-      MigrateStep01.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-
-    expect {
-      MigrateStep02.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-  end
-
-  it 'should allow running same migration data even if it was already migrated' do
-    expect {
-      MigrateStep01.migrate(:up)
-      # Run again
-      MigrateStep01.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-
-    expect {
-      MigrateStep02.migrate(:up)
-      # Run again
-      MigrateStep02.migrate(:up)
-      reset_columns_data
-    }.to_not change {
-      key_relationships
-    }
-  end
-
-  it 'should allow updation, deletion, and new entity creation' do
-    MigrateAllOneGo.migrate(:up)
-    reset_columns_data
-
-    # Select a random student
-    student = Student.all.to_a.sample
-
-    id= student.id
-    student.name= 'New student 01'
-    student.save
-    student = Student.find(id)
-
-    expect(student.name).to eq 'New student 01'
-
-    expect { student.destroy }.to change { Student.count }.by(-1)
-
-    expect {Student.find(id)}.to raise_exception(ActiveRecord::RecordNotFound)
-
-    student= Student.create(
-        name: 'New student 02',
-        city: City.where(name: 'City 2').first,
-        institution: School.where(name: 'School 1').first
-    )
-
-    expect(City.where(name: 'City 2').first.students.where(name: 'New student 02').first.name).to eq 'New student 02'
-    expect(School.where(name: 'School 1').first.students.where(name: 'New student 02').first.name).to eq 'New student 02'
-
-    College.where(name: 'College 3').first.students << student
-
-    student.reload
-
-    expect(student.institution.name).to eq 'College 3'
   end
 end


### PR DESCRIPTION
### What

As #12 explains, it is usually desirable that UUIDs are generated randomly in order to avoid collisions. Some use cases where this is relevant could be:

- Integrating data from multiple databases.
- Merging tables with similar structure and different data set.

The current approach to transform integer keys into UUIDs is by prepending 0's which does generate valid UUIDs but does not provide the randomness needed to avoid the collisions mentioned above.

### How

This PR approaches the problem aiming for retro-compatibility, adding an optional `seed` parameter to the public methods, which is `nil` by default (keeping the current behavior).

When this parameter is provided, the method `to_uuid_pg`, used to generate the UUIDs from the integer keys, uses the `uuid_generate_v5` function included in the [uuid-ossp Postgres module](https://www.postgresql.org/docs/current/uuid-ossp.html). This method takes a _namespace_ UUID (the seed) and a _name_ (the existing) ID to generate the UUIDs.

### Missed features

There are a couple of features that become unavailable when a seed is provided:

1. Recovering the initial IDs. It is no longer straightforward to recover the original ID from the generated UUID, as it is no longer the result of prepending 0's to the integer key. However, it is possible to generate a [rainbow table](https://en.wikipedia.org/wiki/Rainbow_table) using the same seed to generate a UUID-integer mapping. For that reason, it is advisable to store the UUIDs used to run the migrations.
2. The current implementation of `to_uuid_pg` is idempotent, which means that it can be called on a column one or multiple times without making a difference. This is no longer the case when a seed is provided, so multiple processes on the same dataset must to be avoided.

Tests have been updated accordingly.